### PR TITLE
Fix water level check bug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,12 +239,12 @@ void check_update_soil(int valueSoil)
   {
     Serial.println("Updating soil moisture value");
     preferences.putUInt("soilValue", valueSoil);
-    preferences.end();
   }
   else
   {
     Serial.println("Soil moisture value is the same");
   }
+  preferences.end();
 }
 
 /**
@@ -329,7 +329,8 @@ bool check_water_level()
   int waterLevelPercentage = map(waterLevel, 4095, 0, 0, 100);
   Serial.println("Water level percentage: ");
   Serial.println(waterLevelPercentage);
-  if (waterLevel == HIGH)
+  // consider the water level ok if the percentage is greater than 20%
+  if (waterLevelPercentage > 20)
   {
     Serial.println("Water level is ok");
     return true;


### PR DESCRIPTION
## Summary
- fix wrong analog reading check in `check_water_level`
- ensure Preferences are always closed in `check_update_soil`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68489471fcc8832d9979be3dd1b3607f